### PR TITLE
Add REPL `exports` command backed by optional LIEF integration

### DIFF
--- a/.github/workflows/dockcross.yml
+++ b/.github/workflows/dockcross.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Dependencies
-        run: brew install libffi readline llvm
+        run: brew install libffi readline llvm lief
 
       - name: Configure CMake
         run: brew sh -c "mkdir build && cd build && cmake  .."

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -18,7 +18,7 @@ jobs:
 
     - name: Install Dependencies (macOS)
       if: runner.os == 'macOS'
-      run: brew install libffi cmake
+      run: brew install libffi cmake lief
 
     - name: Configure CMake (macOS)
       if: runner.os == 'macOS'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(cliffi VERSION 1.0 LANGUAGES C)
+project(cliffi VERSION 1.0 LANGUAGES C CXX)
 
 enable_testing()
 
@@ -82,12 +82,16 @@ src/tokenize.c
 src/parse_address.c
 src/shims.c
 src/exception_handling.c
+src/export_symbols.cpp
 )
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 add_library(cliffi_common_deps INTERFACE)
+
+# LIEF is optional for local/pkg-config builds and enabled via Conan/CMakeDeps in cross-platform CI.
+set(CLIFFI_HAS_LIEF OFF)
 
 # Target executable
 add_executable(cliffi ${CLIFFI_COMMON_SOURCES})
@@ -98,12 +102,19 @@ find_package(PkgConfig REQUIRED)
 
 pkg_search_module(LIBFFI libffi REQUIRED)
 pkg_search_module(READLINE readline REQUIRED)
+pkg_search_module(LIEF_CPP QUIET lief)
 
 
 target_link_libraries(cliffi_common_deps INTERFACE
 ${LIBFFI_LIBRARIES}
 ${READLINE_LIBRARIES}
 )
+
+if(LIEF_CPP_FOUND)
+    target_include_directories(cliffi_common_deps INTERFACE ${LIEF_CPP_INCLUDE_DIRS})
+    target_link_libraries(cliffi_common_deps INTERFACE ${LIEF_CPP_LIBRARIES})
+    set(CLIFFI_HAS_LIEF ON)
+endif()
 
 endif()
 # Append the project root directory to CMAKE_PREFIX_PATH
@@ -126,6 +137,12 @@ target_link_libraries(cliffi_common_deps INTERFACE readline::readline)
 message(STATUS "readline include dirs: ${readline_INCLUDE_DIRS}")
 message("attempting link readline::readline")
 endif()
+
+set(lief_DIR ${CMAKE_SOURCE_DIR}/build)
+set(ENV{lief_DIR} ${CMAKE_SOURCE_DIR}/build)
+find_package(lief REQUIRED)
+target_link_libraries(cliffi_common_deps INTERFACE lief::lief)
+set(CLIFFI_HAS_LIEF ON)
 endif()
 
 if(NOT ANDROID) # on android this breaks things
@@ -142,6 +159,7 @@ target_include_directories(cliffi_common_deps INTERFACE
         )
 
 target_link_libraries(cliffi PRIVATE cliffi_common_deps)
+target_compile_definitions(cliffi PRIVATE $<$<BOOL:${CLIFFI_HAS_LIEF}>:CLIFFI_HAS_LIEF>)
 
 # Compile cliffi_testlib.c into a shared library
 add_library(cliffitest SHARED test/lib/cliffi_testlib.c)
@@ -181,6 +199,7 @@ target_link_libraries(cliffi_unit_tests PRIVATE
     unity               # The Unity testing framework library
 )
 target_compile_definitions(cliffi_unit_tests PRIVATE CLIFFI_UNIT_TESTING) # this prevents main() from main.c from being compiled
+target_compile_definitions(cliffi_unit_tests PRIVATE $<$<BOOL:${CLIFFI_HAS_LIEF}>:CLIFFI_HAS_LIEF>)
 
 
 add_test(NAME cliffi_unit_tests COMMAND cliffi_unit_tests)
@@ -1338,6 +1357,5 @@ set_tests_properties(is_equal_true_test PROPERTIES PASS_REGULAR_EXPRESSION "Func
 add_test(NAME test_nonzero_exit_for_nonexistent_function
         COMMAND cliffi ${TESTLIB} i non_existent_function 1 2)
 set_tests_properties(test_nonzero_exit_for_nonexistent_function PROPERTIES WILL_FAIL TRUE) # this test is expected to fail
-
 
 

--- a/README.md
+++ b/README.md
@@ -149,11 +149,12 @@ addr_pointer = -P intpointer
 
 In REPL mode, there are `load`, `dump`, and `store` to respectively load a value from a memory address, print a value from a memory address, or store a value to a memory address.
 
-There are also commands to do a `hexdump` from a memory address, and `calculate_offset` to calculate a memory offset (and store the offset to a variable) for a particular library loaded into memory, relative to some reference layout, given a known symbol (ie function) name and reference address. This is helpful for calculating the actual locations of various stripped global and static variables from their addresses in the binary.
+There are also commands to do a `hexdump` from a memory address, `exports <library>` to list exported symbols/functions from a shared library, and `calculate_offset` to calculate a memory offset (and store the offset to a variable) for a particular library loaded into memory, relative to some reference layout, given a known symbol (ie function) name and reference address. This is helpful for calculating the actual locations of various stripped global and static variables from their addresses in the binary.
 
 For example if in your decompiler, there is a static struct `{ int; short; char*; }` of interest at `0x10beef`, you can find the address of an exported function doFoo() at `0x10dead`, calculate the offset and store it in a variable, and then reference it.
 ```
 calculate_offset myoffset mysharedlib.so doFoo 0x10dead  // calculate the offset
+exports mysharedlib.so                   // list exports/symbols (LIEF-backed)
 hexdump myoffset+0x10beef 16             // to just see 16 bytes at that address
 dump S: i h s :S myoffset+0x10beef       // to dump the struct presently at that address
 store myoffset+0x10beef -S: 20 -h 0x6008 hello :S // to store that value into that address

--- a/cliffi.rb
+++ b/cliffi.rb
@@ -6,6 +6,7 @@ class Cliffi < Formula
   license "MIT"
 
   depends_on "cmake" => [:build, :test]
+  depends_on "lief"
   uses_from_macos "libffi"
 
   def install

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,3 +1,4 @@
 [requires]
 libffi/3.4.6
 readline/8.2
+lief/0.15.1

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,4 +1,4 @@
 [requires]
 libffi/3.4.6
 readline/8.2
-lief/0.15.1
+lief/0.16.2

--- a/src/export_symbols.cpp
+++ b/src/export_symbols.cpp
@@ -1,0 +1,38 @@
+#include "export_symbols.h"
+
+#include <stdio.h>
+
+#if defined(CLIFFI_HAS_LIEF)
+#include <LIEF/LIEF.hpp>
+#include <memory>
+
+bool list_exported_symbols_with_lief(const char* library_path) {
+    std::unique_ptr<LIEF::Binary> binary = LIEF::Parser::parse(library_path);
+    if (!binary) {
+        fprintf(stderr, "Error: Failed to parse '%s' using LIEF\n", library_path);
+        return false;
+    }
+
+    size_t exported_count = 0;
+    for (const LIEF::Symbol& symbol : binary->symbols()) {
+        if (!symbol.is_exported()) {
+            continue;
+        }
+        printf("%s\n", symbol.name().c_str());
+        exported_count++;
+    }
+
+    printf("Total exported symbols: %zu\n", exported_count);
+    return true;
+}
+
+#else
+
+bool list_exported_symbols_with_lief(const char* library_path) {
+    (void)library_path;
+    fprintf(stderr,
+            "Error: This build does not include LIEF support. Rebuild with a LIEF dependency to use 'exports'.\n");
+    return false;
+}
+
+#endif

--- a/src/export_symbols.h
+++ b/src/export_symbols.h
@@ -1,0 +1,16 @@
+#ifndef EXPORT_SYMBOLS_H
+#define EXPORT_SYMBOLS_H
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool list_exported_symbols_with_lief(const char* library_path);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,7 @@
 #include "return_formatter.h"
 #include "types_and_utils.h"
 #include "var_map.h"
+#include "export_symbols.h"
 
 #include <stdarg.h>
 #include <stdbool.h>
@@ -540,6 +541,26 @@ void parseHexdump(char* hexdumpCommand) {
 
 
 
+void parseListExports(char* exportsCommand) {
+    int argc;
+    char** argv;
+    tokenize(exportsCommand, &argc, &argv);
+    if (argc < 1) {
+        raiseException(1,  "Error: Invalid number of arguments for exports\n");
+        return;
+    }
+
+    char* resolvedPath = resolve_library_path(argv[0]);
+    if (resolvedPath == NULL) {
+        raiseException(1,  "Error: Could not resolve library path for '%s'\n", argv[0]);
+        return;
+    }
+
+    if (!list_exported_symbols_with_lief(resolvedPath)) {
+        raiseException(1,  "Error: Failed to list exported symbols for '%s'\n", resolvedPath);
+    }
+}
+
 int parseREPLCommand(char* command){
         command = trim_whitespace(command);
         if (strlen(command) > 0) {
@@ -564,6 +585,7 @@ int parseREPLCommand(char* command){
                        "  hexdump <address> <size>: Print a hexdump of memory\n"
                        "Shared Library Management:\n"
                        "  list: List all opened libraries\n"
+                       "  exports <library>: List exported symbols/functions for a library (LIEF-backed)\n"
                        "  close <library>: Close the specified library\n"
                        "  closeall: Close all opened libraries\n"
                        "Shell commands:\n"
@@ -575,6 +597,8 @@ int parseREPLCommand(char* command){
                 print_usage(">");
             } else if (strcmp(command, "list") == 0) {
                 listOpenedLibraries();
+            } else if (strncmp(command, "exports ", 8) == 0) {
+                parseListExports(command + 8);
             } else if (strncmp(command, "close", 5) == 0) {
                 char* libraryName = command + 5;
                 while (*libraryName == ' ') {


### PR DESCRIPTION
### Motivation
- Provide an easy REPL command to list exported symbols/functions from a shared library in a cross-platform, cross-architecture way using LIEF when available. 
- Integrate LIEF consistently with existing dependency patterns so cross-target CI (Conan/CMakeDeps / find_package) can supply LIEF across architectures while allowing local builds to remain optional.

### Description
- Add a new LIEF-backed module `src/export_symbols.cpp` and header `src/export_symbols.h` that expose `list_exported_symbols_with_lief()` and print exported symbol names when `CLIFFI_HAS_LIEF` is enabled.
- Add a new REPL command parser `parseListExports()` and wire `exports <library>` into `src/main.c` (help text, command routing, and error handling) to call the new module.
- Update `CMakeLists.txt` to enable C++ compilation, add `export_symbols.cpp` to sources, and detect/link LIEF via pkg-config or `find_package(lief)` depending on the build flow; expose `CLIFFI_HAS_LIEF` compile-time definition when found.
- Add `lief/0.15.1` to `conanfile.txt`, update `README.md` docs, Homebrew formula `cliffi.rb`, and macOS CI steps to include LIEF so cross-arch CI can supply the dependency.
- Provide a graceful runtime fallback: if LIEF is not available in the build, `exports` prints a clear error instructing users to rebuild with LIEF support.

### Testing
- Configured and built with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` and `cmake --build build -j4` successfully. 
- Ran the full test suite with `ctest --output-on-failure` and all unit/integration tests passed (`156/156` tests passed).
- Manually exercised the new REPL command with a local build lacking LIEF: `printf 'exports ./build/libcliffi_test.so\nexit\n' | ./build/cliffi --repl` and observed the graceful fallback error message (expected behavior).
- Attempted `conan install` to validate Conan/CMakeDeps flow but `conan` was not available in the environment, so cross-arch package validation was not executed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b06bddcc588320b85d78975f6a976a)